### PR TITLE
Get rid of RAILS_ENV deprecation warnings in Rails 3

### DIFF
--- a/lib/paperclip-s3/railtie.rb
+++ b/lib/paperclip-s3/railtie.rb
@@ -7,7 +7,7 @@ module Paperclip
           ActiveSupport.on_load :active_record do
             Paperclip::S3::Railtie.insert
           end
-        end      
+        end
       end
     end
 
@@ -22,7 +22,7 @@ module Paperclip
         end
 
         ActiveRecord::Base.send(:include, Paperclip::S3::Glue) if in_production
-      end 
+      end
     end
   end
 end


### PR DESCRIPTION
Minor change to get rid of a deprecation warning.

Also, in a separate commit, deleted trailing whitespace in the file I modified.

Thanks for the good work,
Dave
